### PR TITLE
Feat/upload image

### DIFF
--- a/OA_Core.Api/Controllers/ImagemController.cs
+++ b/OA_Core.Api/Controllers/ImagemController.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using OA_Core.Domain.Interfaces.Service;
+
+namespace OA_Core.Api.Controllers
+{
+	[ApiController]
+	[Route("api/imagems")]
+	public class ImagemController : ControllerBase
+	{
+		private readonly IImagemService _imagemService;
+
+		public ImagemController(IImagemService imagemService)
+		{
+			_imagemService = imagemService;
+		}
+
+		[HttpPost("upload")]
+		public async Task<IActionResult> UploadImagem([FromForm] IFormFile file)
+		{
+			if (file == null || file.Length == 0)
+			{
+				return BadRequest("Arquivo não enviado.");
+			}
+
+			try
+			{
+				var imageUrl = await _imagemService.SaveImageAsync(file);
+
+				return Ok(new { imageUrl });
+			}
+			catch (Exception ex)
+			{
+				return StatusCode(500, $"Erro interno: {ex.Message}");
+			}
+		}
+	}
+
+}

--- a/OA_Core.Api/Controllers/ImagemController.cs
+++ b/OA_Core.Api/Controllers/ImagemController.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using OA_Core.Domain.Enums;
 using OA_Core.Domain.Interfaces.Service;
 
 namespace OA_Core.Api.Controllers
@@ -15,7 +16,7 @@ namespace OA_Core.Api.Controllers
 		}
 
 		[HttpPost("upload")]
-		public async Task<IActionResult> UploadImagem([FromForm] IFormFile file)
+		public async Task<IActionResult> UploadImagem([FromForm] IFormFile file, TipoImagem tipoImagem)
 		{
 			if (file == null || file.Length == 0)
 			{
@@ -24,7 +25,7 @@ namespace OA_Core.Api.Controllers
 
 			try
 			{
-				var imageUrl = await _imagemService.SaveImageAsync(file);
+				var imageUrl = await _imagemService.SaveImageAsync(file, tipoImagem);
 
 				return Ok(imageUrl);
 			}

--- a/OA_Core.Api/Controllers/ImagemController.cs
+++ b/OA_Core.Api/Controllers/ImagemController.cs
@@ -18,21 +18,9 @@ namespace OA_Core.Api.Controllers
 		[HttpPost("upload")]
 		public async Task<IActionResult> UploadImagem([FromForm] IFormFile file, TipoImagem tipoImagem)
 		{
-			if (file == null || file.Length == 0)
-			{
-				return BadRequest("Arquivo não enviado.");
-			}
+			var imageUrl = await _imagemService.SaveImageAsync(file, tipoImagem);
 
-			try
-			{
-				var imageUrl = await _imagemService.SaveImageAsync(file, tipoImagem);
-
-				return Ok(imageUrl);
-			}
-			catch (Exception ex)
-			{
-				return StatusCode(500, $"Erro interno: {ex.Message}");
-			}
+			return Ok(imageUrl);
 		}
 	}
 

--- a/OA_Core.Api/Controllers/ImagemController.cs
+++ b/OA_Core.Api/Controllers/ImagemController.cs
@@ -26,7 +26,7 @@ namespace OA_Core.Api.Controllers
 			{
 				var imageUrl = await _imagemService.SaveImageAsync(file);
 
-				return Ok(new { imageUrl });
+				return Ok(imageUrl);
 			}
 			catch (Exception ex)
 			{

--- a/OA_Core.Api/Program.cs
+++ b/OA_Core.Api/Program.cs
@@ -43,8 +43,8 @@ builder.Services.AddDbContext<CoreDbContext>(options =>
 
 builder.Services.AddMvc(options =>
 {
-    options.Filters.Add<NotificatonFilter>();
-    options.Filters.Add<ExceptionFilter>();
+	options.Filters.Add<NotificatonFilter>();
+	options.Filters.Add<ExceptionFilter>();
 });
 
 #endregion
@@ -62,6 +62,8 @@ builder.Services.AddScoped<IAlunoService, AlunoService>();
 builder.Services.AddScoped<IAlunoRepository, AlunoRepository>();
 builder.Services.AddScoped<IAulaRepository, AulaRepository>();
 builder.Services.AddScoped<IAulaService, AulaService>();
+builder.Services.AddScoped<IImagemService, ImagemService>();
+
 
 #endregion
 
@@ -74,6 +76,7 @@ if (app.Environment.IsDevelopment())
     app.UseSwagger();
     app.UseSwaggerUI();
 }
+app.UseStaticFiles();
 
 app.UseHttpsRedirection();
 

--- a/OA_Core.Domain/Enums/TipoImagem.cs
+++ b/OA_Core.Domain/Enums/TipoImagem.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OA_Core.Domain.Enums
+{
+	public enum TipoImagem
+	{	
+		fotoProfessor,
+		fotoCurso,
+		fotoAluno,
+		fotoOutro
+	}
+}

--- a/OA_Core.Domain/Interfaces/Service/IImagemService.cs
+++ b/OA_Core.Domain/Interfaces/Service/IImagemService.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Http;
+using OA_Core.Domain.Enums;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,7 +10,7 @@ namespace OA_Core.Domain.Interfaces.Service
 {
 	public interface IImagemService
 	{
-		Task<string> SaveImageAsync(IFormFile file);
+		Task<string> SaveImageAsync(IFormFile file, TipoImagem tipoImagem);
 
 	}
 }

--- a/OA_Core.Domain/Interfaces/Service/IImagemService.cs
+++ b/OA_Core.Domain/Interfaces/Service/IImagemService.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.AspNetCore.Http;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OA_Core.Domain.Interfaces.Service
+{
+	public interface IImagemService
+	{
+		Task<string> SaveImageAsync(IFormFile file);
+
+	}
+}

--- a/OA_Core.Domain/OA_Core.Domain.csproj
+++ b/OA_Core.Domain/OA_Core.Domain.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="12.0.1" />
     <PackageReference Include="FluentValidation" Version="11.7.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="5.0.17" />
   </ItemGroup>
 
 </Project>

--- a/OA_Core.Service/ImagemService.cs
+++ b/OA_Core.Service/ImagemService.cs
@@ -4,6 +4,8 @@ using OA_Core.Domain.Interfaces.Service;
 using static System.Net.Mime.MediaTypeNames;
 using System.IO;
 using OA_Core.Domain.Enums;
+using OA_Core.Domain.Interfaces.Notifications;
+using OA_Core.Domain.Exceptions;
 
 namespace OA_Core.Service
 {
@@ -22,7 +24,12 @@ namespace OA_Core.Service
 		{
 			if (file == null || file.Length == 0)
 			{
-				throw new ArgumentException("Arquivo inválido");
+				throw new InformacaoException(StatusException.FormatoIncorreto, $"Arquivo não encontrado");
+			}
+
+			if (!file.ContentType.StartsWith("image"))
+			{
+				throw new InformacaoException(StatusException.FormatoIncorreto, $"Formato de arquivo inválido");
 			}
 
 			string caminhoImagem = TipoImagem.ToString().ToLower(); // Use o nome da enumeração em minúsculas
@@ -33,7 +40,6 @@ namespace OA_Core.Service
 			//Cerficica que a subpasta existe, criando se seja necessário.
 			string subfolderPath = Path.Combine(_imageFolderPath, caminhoImagem);
 			Directory.CreateDirectory(subfolderPath);
-
 
 			// Formata nome do arquivo
 			string filename = Path.GetFileNameWithoutExtension(file.FileName);

--- a/OA_Core.Service/ImagemService.cs
+++ b/OA_Core.Service/ImagemService.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Hosting;
+using OA_Core.Domain.Interfaces.Service;
+using static System.Net.Mime.MediaTypeNames;
+using System.IO;
+
+namespace OA_Core.Service
+{
+	public class ImagemService : IImagemService
+	{
+		private readonly IHostingEnvironment _environment;
+		private readonly string _imageFolderPath;
+
+		public ImagemService(IHostingEnvironment environment)
+		{
+			_environment = environment;
+			_imageFolderPath = Path.Combine(_environment.ContentRootPath, "images");
+		}
+
+		public async Task<string> SaveImageAsync(IFormFile file)
+		{
+			if (file == null || file.Length == 0)
+			{
+				throw new ArgumentException("Arquivo inválido");
+			}
+
+			// Certifica de que a pasta "images" existe, criando ela se necessário.
+			Directory.CreateDirectory(_imageFolderPath);
+
+			// Formata nome do arquivo
+			string filename = file.FileName.Split('.')[0];
+
+			// Gere um nome de arquivo único para evitar conflitos.
+			string uniqueFileName = filename + "_" + Guid.NewGuid().ToString() + ".jpg";
+
+			// Combine o caminho completo do arquivo.
+			string filePath = Path.Combine(_imageFolderPath, uniqueFileName);
+
+			// Salve o arquivo no diretório de imagens.
+			using (var fileStream = new FileStream(filePath, FileMode.Create))
+			{
+				await file.CopyToAsync(fileStream);
+			}
+		
+			// Retorne o caminho completo do arquivo para uso futuro.
+			return Path.Combine("images", uniqueFileName);
+		}
+	}
+}

--- a/OA_Core.Service/ImagemService.cs
+++ b/OA_Core.Service/ImagemService.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Hosting;
 using OA_Core.Domain.Interfaces.Service;
 using static System.Net.Mime.MediaTypeNames;
 using System.IO;
+using OA_Core.Domain.Enums;
 
 namespace OA_Core.Service
 {
@@ -17,33 +18,40 @@ namespace OA_Core.Service
 			_imageFolderPath = Path.Combine(_environment.ContentRootPath, "images");
 		}
 
-		public async Task<string> SaveImageAsync(IFormFile file)
+		public async Task<string> SaveImageAsync(IFormFile file, TipoImagem TipoImagem)
 		{
 			if (file == null || file.Length == 0)
 			{
 				throw new ArgumentException("Arquivo inválido");
 			}
 
+			string caminhoImagem = TipoImagem.ToString().ToLower(); // Use o nome da enumeração em minúsculas
+
 			// Certifica de que a pasta "images" existe, criando ela se necessário.
 			Directory.CreateDirectory(_imageFolderPath);
 
+			//Cerficica que a subpasta existe, criando se seja necessário.
+			string subfolderPath = Path.Combine(_imageFolderPath, caminhoImagem);
+			Directory.CreateDirectory(subfolderPath);
+
+
 			// Formata nome do arquivo
-			string filename = file.FileName.Split('.')[0];
+			string filename = Path.GetFileNameWithoutExtension(file.FileName);
 
 			// Gere um nome de arquivo único para evitar conflitos.
-			string uniqueFileName = filename + "_" + Guid.NewGuid().ToString() + ".jpg";
+			string uniqueFileName = filename + "_" + Guid.NewGuid().ToString() + Path.GetExtension(file.FileName);
 
 			// Combine o caminho completo do arquivo.
-			string filePath = Path.Combine(_imageFolderPath, uniqueFileName);
+			string filePath = Path.Combine(subfolderPath, uniqueFileName);
 
 			// Salve o arquivo no diretório de imagens.
 			using (var fileStream = new FileStream(filePath, FileMode.Create))
 			{
 				await file.CopyToAsync(fileStream);
 			}
-		
+
 			// Retorne o caminho completo do arquivo para uso futuro.
-			return Path.Combine("images", uniqueFileName);
+			return Path.Combine("images", caminhoImagem, uniqueFileName);
 		}
 	}
 }

--- a/OA_Core.Service/OA_Core.Service.csproj
+++ b/OA_Core.Service/OA_Core.Service.csproj
@@ -7,6 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="5.0.17" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\OA_Core.Domain\OA_Core.Domain.csproj" />
   </ItemGroup>
 

--- a/OA_Core.Tests/Controller/ImagemControllerTest.cs
+++ b/OA_Core.Tests/Controller/ImagemControllerTest.cs
@@ -1,0 +1,103 @@
+﻿using AutoFixture;
+using AutoMapper;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using MySqlX.XDevAPI.Common;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using OA_Core.Api.Controllers;
+using OA_Core.Domain.Contracts.Request;
+using OA_Core.Domain.Contracts.Response;
+using OA_Core.Domain.Entities;
+using OA_Core.Domain.Interfaces.Service;
+using OA_Core.Repository.Repositories;
+using OA_Core.Service;
+using OA_Core.Tests.Config;
+using Org.BouncyCastle.Asn1.Ocsp;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OA_Core.Tests.Controller
+{
+	[Trait("Controller", "Curso Controller Test")]
+	public class ImagemControllerTest
+	{
+		private readonly Fixture _fixture;
+		private readonly IImagemService _service;
+		private readonly IMapper _mapper;
+
+		public ImagemControllerTest()
+		{
+			_mapper = MapperConfig.Get();
+			_fixture = FixtureConfig.GetFixture();
+			_service = Substitute.For<IImagemService>();
+		}
+
+		[Fact(DisplayName = "Adiciona uma imagem")]
+		public async Task UploadImagem()
+		{
+			var imagemController = new ImagemController(_service);
+
+			var formFile = Substitute.For<IFormFile>();
+			formFile.Length.Returns(100); // Set a valid file length
+			formFile.FileName.Returns("test_image");
+
+			_service.SaveImageAsync(formFile).Returns("okResult");
+
+			var controllerResult = await imagemController.UploadImagem(formFile);
+
+			controllerResult.Should().NotBeNull();
+			controllerResult.Should().BeAssignableTo<OkObjectResult>();
+
+			var result = controllerResult as OkObjectResult;
+
+			result.StatusCode.Should().Be(StatusCodes.Status200OK);
+			result.Value.Should().Be("okResult");
+		}
+
+		[Fact(DisplayName = "Adiciona uma imagem invalida")]
+		public async Task UploadImagemInvalida()
+		{
+			var imagemController = new ImagemController(_service);
+
+			var formFile = Substitute.For<IFormFile>();
+			formFile.Length.Returns(0); // Set a valid file length
+			formFile.FileName.Returns("test_image");
+
+			var controllerResult = await imagemController.UploadImagem(formFile);
+
+			controllerResult.Should().NotBeNull();
+			controllerResult.Should().BeAssignableTo<BadRequestObjectResult>();
+
+			var result = controllerResult as BadRequestObjectResult;
+
+			result.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+			result.Value.Should().Be("Arquivo não enviado.");
+		}
+
+		[Fact(DisplayName = "Adiciona uma imagem invalida validação service")]
+		public async Task UploadImagemInvalidaNaService()
+		{
+			var imagemController = new ImagemController(_service);
+
+			var formFile = Substitute.For<IFormFile>();
+			formFile.Length.Returns(100); // Set a valid file length
+			formFile.FileName.Returns("test_image");
+
+			_service.SaveImageAsync(formFile).Throws(new ArgumentException("Arquivo inválido"));
+
+			var controllerResult = await imagemController.UploadImagem(formFile);
+
+			controllerResult.Should().NotBeNull();
+			controllerResult.Should().BeAssignableTo<ObjectResult>();
+
+			var result = controllerResult as ObjectResult;
+
+			result.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
+		}
+	}
+}

--- a/OA_Core.Tests/Controller/ImagemControllerTest.cs
+++ b/OA_Core.Tests/Controller/ImagemControllerTest.cs
@@ -49,7 +49,7 @@ namespace OA_Core.Tests.Controller
 			var tipoimagem = TipoImagem.fotoOutro;
 
 
-			_service.SaveImageAsync(formFile, tipoimagem).Returns("okResult");
+			_service.SaveImageAsync(formFile, tipoimagem).Returns("mock_resultado_sem_problemas");
 
 			var controllerResult = await imagemController.UploadImagem(formFile, tipoimagem);
 
@@ -59,53 +59,7 @@ namespace OA_Core.Tests.Controller
 			var result = controllerResult as OkObjectResult;
 
 			result.StatusCode.Should().Be(StatusCodes.Status200OK);
-			result.Value.Should().Be("okResult");
-		}
-
-		[Fact(DisplayName = "Adiciona uma imagem invalida")]
-		public async Task UploadImagemInvalida()
-		{
-			var imagemController = new ImagemController(_service);
-
-			var formFile = Substitute.For<IFormFile>();
-			formFile.Length.Returns(0); // Set a valid file length
-			formFile.FileName.Returns("test_image");
-			var tipoimagem = TipoImagem.fotoOutro;
-
-
-			var controllerResult = await imagemController.UploadImagem(formFile, tipoimagem);
-
-			controllerResult.Should().NotBeNull();
-			controllerResult.Should().BeAssignableTo<BadRequestObjectResult>();
-
-			var result = controllerResult as BadRequestObjectResult;
-
-			result.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
-			result.Value.Should().Be("Arquivo não enviado.");
-		}
-
-		[Fact(DisplayName = "Adiciona uma imagem invalida validação service")]
-		public async Task UploadImagemInvalidaNaService()
-		{
-			var imagemController = new ImagemController(_service);
-
-			var formFile = Substitute.For<IFormFile>();
-			formFile.Length.Returns(100); // Set a valid file length
-			formFile.FileName.Returns("test_image");
-
-			var tipoimagem = TipoImagem.fotoOutro;
-
-
-			_service.SaveImageAsync(formFile, tipoimagem).Throws(new ArgumentException("Arquivo inválido"));
-
-			var controllerResult = await imagemController.UploadImagem(formFile, tipoimagem);
-
-			controllerResult.Should().NotBeNull();
-			controllerResult.Should().BeAssignableTo<ObjectResult>();
-
-			var result = controllerResult as ObjectResult;
-
-			result.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
+			result.Value.Should().Be("mock_resultado_sem_problemas");
 		}
 	}
 }

--- a/OA_Core.Tests/Controller/ImagemControllerTest.cs
+++ b/OA_Core.Tests/Controller/ImagemControllerTest.cs
@@ -10,6 +10,7 @@ using OA_Core.Api.Controllers;
 using OA_Core.Domain.Contracts.Request;
 using OA_Core.Domain.Contracts.Response;
 using OA_Core.Domain.Entities;
+using OA_Core.Domain.Enums;
 using OA_Core.Domain.Interfaces.Service;
 using OA_Core.Repository.Repositories;
 using OA_Core.Service;
@@ -45,10 +46,12 @@ namespace OA_Core.Tests.Controller
 			var formFile = Substitute.For<IFormFile>();
 			formFile.Length.Returns(100); // Set a valid file length
 			formFile.FileName.Returns("test_image");
+			var tipoimagem = TipoImagem.fotoOutro;
 
-			_service.SaveImageAsync(formFile).Returns("okResult");
 
-			var controllerResult = await imagemController.UploadImagem(formFile);
+			_service.SaveImageAsync(formFile, tipoimagem).Returns("okResult");
+
+			var controllerResult = await imagemController.UploadImagem(formFile, tipoimagem);
 
 			controllerResult.Should().NotBeNull();
 			controllerResult.Should().BeAssignableTo<OkObjectResult>();
@@ -67,8 +70,10 @@ namespace OA_Core.Tests.Controller
 			var formFile = Substitute.For<IFormFile>();
 			formFile.Length.Returns(0); // Set a valid file length
 			formFile.FileName.Returns("test_image");
+			var tipoimagem = TipoImagem.fotoOutro;
 
-			var controllerResult = await imagemController.UploadImagem(formFile);
+
+			var controllerResult = await imagemController.UploadImagem(formFile, tipoimagem);
 
 			controllerResult.Should().NotBeNull();
 			controllerResult.Should().BeAssignableTo<BadRequestObjectResult>();
@@ -88,9 +93,12 @@ namespace OA_Core.Tests.Controller
 			formFile.Length.Returns(100); // Set a valid file length
 			formFile.FileName.Returns("test_image");
 
-			_service.SaveImageAsync(formFile).Throws(new ArgumentException("Arquivo inválido"));
+			var tipoimagem = TipoImagem.fotoOutro;
 
-			var controllerResult = await imagemController.UploadImagem(formFile);
+
+			_service.SaveImageAsync(formFile, tipoimagem).Throws(new ArgumentException("Arquivo inválido"));
+
+			var controllerResult = await imagemController.UploadImagem(formFile, tipoimagem);
 
 			controllerResult.Should().NotBeNull();
 			controllerResult.Should().BeAssignableTo<ObjectResult>();

--- a/OA_Core.Tests/Service/ImagemServiceTest.cs
+++ b/OA_Core.Tests/Service/ImagemServiceTest.cs
@@ -33,9 +33,12 @@ namespace OA_Core.Tests.Service
 			// Act
 			var result = await imagemService.SaveImageAsync(formFile, tipoimagem);
 
+			var expectedPath = Path.Combine("images", tipoimagem.ToString().ToLower(), "test_image");
+
+
 			// Assert
 			result.Should().NotBeNullOrEmpty();
-			result.Should().StartWith("images");
+			result.Should().StartWith(expectedPath);
 		}
 
 		[Fact]

--- a/OA_Core.Tests/Service/ImagemServiceTest.cs
+++ b/OA_Core.Tests/Service/ImagemServiceTest.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using NSubstitute;
+using OA_Core.Domain.Enums;
 using OA_Core.Service;
 using System;
 using System.Collections.Generic;
@@ -24,14 +25,17 @@ namespace OA_Core.Tests.Service
 			formFile.Length.Returns(100); // Set a valid file length
 			formFile.FileName.Returns("test_image");
 
+			var tipoimagem = TipoImagem.fotoOutro;
+
+
 			var imagemService = new ImagemService(hostingEnvironment);
 
 			// Act
-			var result = await imagemService.SaveImageAsync(formFile);
+			var result = await imagemService.SaveImageAsync(formFile, tipoimagem);
 
 			// Assert
 			result.Should().NotBeNullOrEmpty();
-			result.Should().StartWith("images\\test_image");
+			result.Should().StartWith("images\\fotooutro\\test_image");
 		}
 
 		[Fact]
@@ -45,10 +49,12 @@ namespace OA_Core.Tests.Service
 			formFile.Length.Returns(0);
 			formFile.FileName.Returns("invalid_image.jpg");
 
+			var tipoimagem = TipoImagem.fotoOutro;
+
 			var imagemService = new ImagemService(hostingEnvironment);
 
 			// Act and Assert
-			Func<Task> action = async () => await imagemService.SaveImageAsync(formFile);
+			Func<Task> action = async () => await imagemService.SaveImageAsync(formFile, tipoimagem);
 			await action.Should().ThrowAsync<ArgumentException>();
 		}
 	}

--- a/OA_Core.Tests/Service/ImagemServiceTest.cs
+++ b/OA_Core.Tests/Service/ImagemServiceTest.cs
@@ -35,7 +35,7 @@ namespace OA_Core.Tests.Service
 
 			// Assert
 			result.Should().NotBeNullOrEmpty();
-			result.Should().StartWith("images\\fotooutro\\test_image");
+			result.Should().StartWith("images");
 		}
 
 		[Fact]

--- a/OA_Core.Tests/Service/ImagemServiceTest.cs
+++ b/OA_Core.Tests/Service/ImagemServiceTest.cs
@@ -1,0 +1,55 @@
+﻿using FluentAssertions;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using NSubstitute;
+using OA_Core.Service;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OA_Core.Tests.Service
+{
+	public class ImagemServiceTests
+	{
+		[Fact]
+		public async Task SaveImageAsync_ValidFile_ReturnsFilePath()
+		{
+			// Arrange
+			var hostingEnvironment = Substitute.For<IHostingEnvironment>();
+			hostingEnvironment.ContentRootPath.Returns("mocked_content_root_path");
+
+			var formFile = Substitute.For<IFormFile>();
+			formFile.Length.Returns(100); // Set a valid file length
+			formFile.FileName.Returns("test_image");
+
+			var imagemService = new ImagemService(hostingEnvironment);
+
+			// Act
+			var result = await imagemService.SaveImageAsync(formFile);
+
+			// Assert
+			result.Should().NotBeNullOrEmpty();
+			result.Should().StartWith("images\\test_image");
+		}
+
+		[Fact]
+		public async Task SaveImageAsync_InvalidFile_ThrowsException()
+		{
+			// Arrange
+			var hostingEnvironment = Substitute.For<IHostingEnvironment>();
+			hostingEnvironment.ContentRootPath.Returns("your_mocked_content_root_path");
+
+			var formFile = Substitute.For<IFormFile>();
+			formFile.Length.Returns(0);
+			formFile.FileName.Returns("invalid_image.jpg");
+
+			var imagemService = new ImagemService(hostingEnvironment);
+
+			// Act and Assert
+			Func<Task> action = async () => await imagemService.SaveImageAsync(formFile);
+			await action.Should().ThrowAsync<ArgumentException>();
+		}
+	}
+}


### PR DESCRIPTION
# Upload de imagem

## Descrição

Feita classe para realizar upload de imagem via DataForm

## Issue relacionada

Fixes #52 - Upload de imagem

## Como testar

- Faça o checkout dessa branch: `git checkout nome-da-branch`
- Instale as dependências: `dotnet restore`
- Rode os testes: `dotnet run`
- Verifique se o resultado é o esperado.

Envio da foto deve ser realizado via Postman com a seguinte configuração:
![image](https://github.com/willsantos/OA_backend_core/assets/116887689/f5a7c5dd-dd83-4759-830c-dd50b26b3b47)

O resultado será o seguinte:
![image](https://github.com/willsantos/OA_backend_core/assets/116887689/8c8404e1-7509-4993-8106-9512d67a7994)

## Checklist

Antes de enviar o PR, verifique se você completou os seguintes itens:

- [x] Eu li as [diretrizes de contribuição](#) do projeto.
- [x] Eu adicionei testes que provam que a minha solução funciona.
- [ ] Eu atualizei a documentação conforme necessário.
- [x] Eu revisei o meu próprio código e corrigi os erros de estilo.
- [x] Eu solicitei a revisão de pelo menos dois outros colaboradores.

