### PR TITLE
feat:Melhora o filtro de Exception 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -482,3 +482,8 @@ $RECYCLE.BIN/
 
 #build
 out
+
+#docs
+level1.puml
+level2.puml
+level3.puml

--- a/OA_Core.Api/Filters/ExceptionFilter.cs
+++ b/OA_Core.Api/Filters/ExceptionFilter.cs
@@ -12,18 +12,25 @@ namespace OA_Core.Api.Filters
         public override Task OnExceptionAsync(ExceptionContext context)
         {
             var response = new InformacaoResponse();
+			var environment = Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT") ?? Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
 
             if (context.Exception is InformacaoException)
             {
                 InformacaoException informacaoException = (InformacaoException)context.Exception;
                 response.Codigo = informacaoException.Codigo;
                 response.Mensagens = informacaoException.Mensagens;
-            } 
+
+				if (environment != Environments.Production)
+					response.MensagemDebug = context.Exception.Message;
+				
+			} 
             else
             {
                 response.Codigo = StatusException.Erro;
                 response.Mensagens = new List<string> { "Erro inesperado " };
-            }
+				if (environment != Environments.Production)
+					response.MensagemDebug = context.Exception.Message;
+			}
 
             context.Result = new ObjectResult(response)
             {

--- a/OA_Core.Domain/Contracts/Response/InformacaoResponse.cs
+++ b/OA_Core.Domain/Contracts/Response/InformacaoResponse.cs
@@ -1,5 +1,6 @@
 ﻿using OA_Core.Domain.Enums;
 using OA_Core.Domain.Utils;
+using System.Text.Json.Serialization;
 
 namespace OA_Core.Domain.Contracts.Response
 {
@@ -7,6 +8,10 @@ namespace OA_Core.Domain.Contracts.Response
     {
         public StatusException Codigo { get; set; }
         public string Descricao { get { return Codigo.Description(); } }
-        public List<string> Mensagens { get; set; }
+        public List<string>? Mensagens { get; set; }
+
+		[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+		public string? MensagemDebug { get; set; }
+		
     }
 }


### PR DESCRIPTION
# Melhora o filtro de Exception 

## Descrição

Faz um melhoramento do Filtro de Exception para exibir erros "crus" quando estamos no ambiente de desenvolvimento, evitando que os devs  desabilitem o filtro ou que não tenham noção de como o erro vai ser exibido para o usuario.

A nova categoria MensagemDebug só irá ser exibida no Json, durante o desenvolvimento.


